### PR TITLE
Add support for reading concatenated .xz files.

### DIFF
--- a/enums.go
+++ b/enums.go
@@ -102,3 +102,20 @@ const (
 	// Mask for preset level. To AND with a Preset to extract the level.
 	LevelMask Preset = 0x1f
 )
+
+// Flags passed to liblzma stream decoder constructors.
+// See liblzma/src/liblzma/api/lzma/container.h.
+type DecoderFlags uint32
+
+const (
+	// Return NoCheck if the input stream has no integrity check.
+	TellNoCheck DecoderFlags = 1
+	// Return UnsupportedCheck if the type of the input stream's integrity check
+	// is not supported by this version of liblzma.
+	TellUnsupportedCheck DecoderFlags = 2
+	// Return GetCheck as soon as the type of the input stream's integrity check
+	// is known.
+	TellAnyCheck DecoderFlags = 4
+	// Enable decoding of concatenated compressed files.
+	Concatenated DecoderFlags = 8
+)

--- a/reader_test.go
+++ b/reader_test.go
@@ -11,8 +11,10 @@ import (
 	"testing"
 )
 
+const testFile = "testdata/go_spec.html.xz"
+
 func TestDecompress(T *testing.T) {
-	f, er := os.Open("testdata/go_spec.html.xz")
+	f, er := os.Open(testFile)
 	if er != nil {
 		T.Fatalf("could not open test file: %s", er)
 	}
@@ -32,14 +34,14 @@ func TestDecompress(T *testing.T) {
 }
 
 func TestDecompressSmall(t *testing.T) {
-	f, _ := os.Open("testdata/go_spec.html.xz")
+	f, _ := os.Open(testFile)
 	dec, _ := NewReader(f)
 	buf := new(bytes.Buffer)
 	io.Copy(buf, dec)
 	contents := buf.Bytes()
 	f.Close()
 
-	f, _ = os.Open("testdata/go_spec.html.xz")
+	f, _ = os.Open(testFile)
 	dec, _ = NewReader(f)
 	var contents2 []byte
 	for {
@@ -54,5 +56,51 @@ func TestDecompressSmall(t *testing.T) {
 
 	if !bytes.Equal(contents, contents2) {
 		t.Fatalf("contents (%d bytes) and contents2 (%d bytes) differ!", len(contents), len(contents2))
+	}
+}
+
+func TestDecompressConcatenated(t *testing.T) {
+	f, err := os.Open(testFile)
+	if err != nil {
+		t.Fatalf("Failed to open test data file: %s", err)
+	}
+	defer f.Close()
+	dec, err := NewReader(f)
+	if err != nil {
+		t.Fatalf("Failed to open decompressor: %s", err)
+	}
+	defer dec.Close()
+	buf := new(bytes.Buffer)
+	io.Copy(buf, dec)
+	contents := buf.Bytes()
+
+	f2a, err := os.Open(testFile)
+	if err != nil {
+		t.Fatalf("Failed to open test data file: %s", err)
+	}
+	defer f2a.Close()
+	f2b, err := os.Open(testFile)
+	if err != nil {
+		t.Fatalf("Failed to open test data file: %s", err)
+	}
+	defer f2b.Close()
+	f2 := io.MultiReader(f2a, f2b)
+	dec2, err := NewReader(f2)
+	if err != nil {
+		t.Fatalf("Failed to open decompressor: %s", err)
+	}
+	defer dec2.Close()
+	buf2 := new(bytes.Buffer)
+	io.Copy(buf2, dec2)
+	contents2 := buf2.Bytes()
+
+	if 2*len(contents) != len(contents2) {
+		t.Fatalf("contents2 has wrong length (expected %d bytes, got %d bytes)", 2*len(contents), len(contents2))
+	}
+	if !bytes.Equal(contents, contents2[:len(contents)]) {
+		t.Errorf("contents does not match first half (%d bytes) of contents2", len(contents))
+	}
+	if !bytes.Equal(contents, contents2[len(contents):]) {
+		t.Fatalf("contents does not match second half (%d bytes) of contents2", len(contents))
 	}
 }


### PR DESCRIPTION
Pass the LZMA_CONCATENATED flag to lzma_auto_decoder(). This changes the
semantics of the decoder slightly (it must be LZMA_FINISHed at the end
of the stream). Update xz.Decompressor.Read() accordingly, doing some
refactoring in the process to clarify the error handling.
