### PR TITLE
Add support for reading concatenated .xz files

### DIFF
--- a/enums.go
+++ b/enums.go
@@ -102,3 +102,20 @@ const (
 	// Mask for preset level. To AND with a Preset to extract the level.
 	LevelMask Preset = 0x1f
 )
+
+// Flags passed to liblzma stream decoder constructors.
+// See liblzma/src/liblzma/api/lzma/container.h.
+const (
+	// tellNoCheck causes lzma_code to return NoCheck if the input stream has
+	// no integrity check.
+	tellNoCheck = 1 << iota
+	// tellUnsupportedCheck causes lzma_code to return UnsupportedCheck if the
+	// type of the input stream's integrity check is not supported by this
+	// version of liblzma.
+	tellUnsupportedCheck
+	// tellAnyCheck causes lzma_code to return GetCheck as soon as the type of
+	// the input stream's integrity check is known.
+	tellAnyCheck
+	// concatenated enables decoding of concatenated compressed files.
+	concatenated
+)

--- a/reader_test.go
+++ b/reader_test.go
@@ -7,12 +7,15 @@ package xz
 import (
 	"bytes"
 	"io"
+	"io/ioutil"
 	"os"
 	"testing"
 )
 
+const testFile = "testdata/go_spec.html.xz"
+
 func TestDecompress(T *testing.T) {
-	f, er := os.Open("testdata/go_spec.html.xz")
+	f, er := os.Open(testFile)
 	if er != nil {
 		T.Fatalf("could not open test file: %s", er)
 	}
@@ -32,14 +35,14 @@ func TestDecompress(T *testing.T) {
 }
 
 func TestDecompressSmall(t *testing.T) {
-	f, _ := os.Open("testdata/go_spec.html.xz")
+	f, _ := os.Open(testFile)
 	dec, _ := NewReader(f)
 	buf := new(bytes.Buffer)
 	io.Copy(buf, dec)
 	contents := buf.Bytes()
 	f.Close()
 
-	f, _ = os.Open("testdata/go_spec.html.xz")
+	f, _ = os.Open(testFile)
 	dec, _ = NewReader(f)
 	var contents2 []byte
 	for {
@@ -54,5 +57,47 @@ func TestDecompressSmall(t *testing.T) {
 
 	if !bytes.Equal(contents, contents2) {
 		t.Fatalf("contents (%d bytes) and contents2 (%d bytes) differ!", len(contents), len(contents2))
+	}
+}
+
+func TestDecompressConcatenated(t *testing.T) {
+	f, err := os.Open(testFile)
+	if err != nil {
+		t.Fatalf("Failed to open test data file: %s", err)
+	}
+	defer f.Close()
+	dec, err := NewReader(f)
+	if err != nil {
+		t.Fatalf("Failed to open decompressor: %s", err)
+	}
+	defer dec.Close()
+	contents, err := ioutil.ReadAll(dec)
+	if err != nil {
+		t.Fatalf("Failed to decompress test data file: %s", err)
+	}
+
+	f2a, err := os.Open(testFile)
+	if err != nil {
+		t.Fatalf("Failed to open test data file: %s", err)
+	}
+	defer f2a.Close()
+	f2b, err := os.Open(testFile)
+	if err != nil {
+		t.Fatalf("Failed to open test data file: %s", err)
+	}
+	defer f2b.Close()
+	dec2, err := NewReader(io.MultiReader(f2a, f2b))
+	if err != nil {
+		t.Fatalf("Failed to open decompressor: %s", err)
+	}
+	defer dec2.Close()
+	got, err := ioutil.ReadAll(dec2)
+	if err != nil {
+		t.Fatalf("Failed to decompress concatenated test data files: %s", err)
+	}
+
+	want := append(append([]byte{}, contents...), contents...)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("NewReader(f) => %q\nNewReader(io.MultiReader(f, f)) => %q\nExpected => %q", contents, got, want)
 	}
 }


### PR DESCRIPTION
Per xz's manpage:

```
Concatenation and padding with .xz files
    It is possible to concatenate .xz files as is. xz will decompress
    such files as if they were a single .xz file.
```

To support this functionality, pass the LZMA_CONCATENATED flag to
lzma_auto_decoder(). This changes the semantics of the decoder slightly
(it must be LZMA_FINISHed at the end of the stream). Update
xz.Decompressor.Read() accordingly.
