### PR TITLE
Protect next_in and next_out pointers from GC relocation.

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -9,14 +9,15 @@ package xz
 #include <lzma.h>
 #include <stdlib.h>
 
-int run_lzma_code(
+int go_lzma_code(
     lzma_stream* handle,
     void* next_in,
-    void* next_out
+    void* next_out,
+    lzma_action action
 ) {
     handle->next_in = next_in;
     handle->next_out = next_out;
-    return lzma_code(handle, LZMA_RUN);
+    return lzma_code(handle, action);
 }
 */
 import "C"
@@ -63,10 +64,11 @@ func (r *Decompressor) Read(out []byte) (out_count int, er error) {
 		r.handle.avail_in = C.size_t(n)
 	}
 	r.handle.avail_out = C.size_t(len(out))
-	ret := C.run_lzma_code(
+	ret := C.go_lzma_code(
 		r.handle,
 		unsafe.Pointer(&r.buffer[r.offset]),
 		unsafe.Pointer(&out[0]),
+		C.lzma_action(Run),
 	)
 	r.offset = r.length - int(r.handle.avail_in)
 	switch Errno(ret) {

--- a/reader.go
+++ b/reader.go
@@ -8,6 +8,16 @@ package xz
 #cgo LDFLAGS: -llzma
 #include <lzma.h>
 #include <stdlib.h>
+
+int run_lzma_code(
+    lzma_stream* handle,
+    void* next_in,
+    void* next_out
+) {
+    handle->next_in = next_in;
+    handle->next_out = next_out;
+    return lzma_code(handle, LZMA_RUN);
+}
 */
 import "C"
 
@@ -20,8 +30,9 @@ import (
 type Decompressor struct {
 	handle *C.lzma_stream
 	rd     io.Reader
-	buffer []byte
-	offset int
+	buffer []byte // buffer allocated when the Decompressor was created to hold data read from rd
+	offset int    // offset of the next byte in the buffer to read
+	length int    // number of actual bytes in the buffer from the reader
 }
 
 var _ io.ReadCloser = &Decompressor{}
@@ -42,19 +53,22 @@ func NewReader(r io.Reader) (*Decompressor, error) {
 }
 
 func (r *Decompressor) Read(out []byte) (out_count int, er error) {
-	if r.offset == len(r.buffer) {
+	if r.offset >= r.length {
 		var n int
 		n, er = r.rd.Read(r.buffer)
 		if n == 0 {
 			return 0, er
 		}
-		r.offset = 0
-		r.handle.next_in = (*C.uint8_t)(unsafe.Pointer(&r.buffer[0]))
+		r.offset, r.length = 0, n
 		r.handle.avail_in = C.size_t(n)
 	}
-	r.handle.next_out = (*C.uint8_t)(unsafe.Pointer(&out[0]))
 	r.handle.avail_out = C.size_t(len(out))
-	ret := C.lzma_code(r.handle, C.lzma_action(Run))
+	ret := C.run_lzma_code(
+		r.handle,
+		unsafe.Pointer(&r.buffer[r.offset]),
+		unsafe.Pointer(&out[0]),
+	)
+	r.offset = r.length - int(r.handle.avail_in)
 	switch Errno(ret) {
 	case Ok:
 		break
@@ -63,8 +77,6 @@ func (r *Decompressor) Read(out []byte) (out_count int, er error) {
 	default:
 		er = Errno(ret)
 	}
-
-	r.offset = len(r.buffer) - int(r.handle.avail_in)
 
 	return len(out) - int(r.handle.avail_out), er
 }


### PR DESCRIPTION
The `next_in` and `next_out` pointers of an `lzma_stream` should not be set to the address of values in Go memory by a Go function.  Otherwise, there is a race during the time between when these pointers are set and when lzma_code uses them, where the Go garbage collector may relocate the values.

Running `env GODEBUG=gocheck=2 go test` will consistently produce a panic; I have seen this issue with increasing frequency after updating to Go 1.8.

The workaround is to pass `next_in` and `next_out` via a CGO call of a C function that wraps `lzma_code`.  This ensures that the GC knows there are pointers to those values for the duration of the `lzma_code` call and will not relocate the values.

See https://godoc.org/cmd/cgo#hdr-Passing_pointers for more information about requirements for using pointers with CGO.

```
scott@worg:~/swdunlop/go-liblzma (HEAD)
$ env GODEBUG=cgocheck=2 go test
write of Go pointer 0xc4213aa000 to non-Go memory 0x22c3400
fatal error: Go pointer stored into non-Go memory

runtime stack:
runtime.throw(0x545c77, 0x24)
	/usr/lib/go/src/runtime/panic.go:596 +0x95
runtime.cgoCheckWriteBarrier.func1()
	/usr/lib/go/src/runtime/cgocheck.go:44 +0xb8
runtime.systemstack(0x7de800)
	/usr/lib/go/src/runtime/asm_amd64.s:327 +0x79
runtime.mstart()
	/usr/lib/go/src/runtime/proc.go:1132

goroutine 3 [running]:
runtime.systemstack_switch()
	/usr/lib/go/src/runtime/asm_amd64.s:281 fp=0xc42002b638 sp=0xc42002b630
runtime.cgoCheckWriteBarrier(0x22c3400, 0xc4213aa000)
	/usr/lib/go/src/runtime/cgocheck.go:45 +0xb6 fp=0xc42002b670 sp=0xc42002b638
runtime.writebarrierptr(0x22c3400, 0xc4213aa000)
	/usr/lib/go/src/runtime/mbarrier.go:199 +0xcc fp=0xc42002b6a8 sp=0xc42002b670
_/home/scott/swdunlop/go-liblzma.(*Decompressor).Read(0xc42007a680, 0xc4200a9000, 0x800, 0x800, 0x0, 0xc42007c3c8, 0x1)
	/home/scott/swdunlop/go-liblzma/reader.go:52 +0x200 fp=0xc42002b710 sp=0xc42002b6a8
_/home/scott/swdunlop/go-liblzma.TestDecompress(0xc42007c340)
	/home/scott/swdunlop/go-liblzma/reader_test.go:24 +0x15c fp=0xc42002b7a8 sp=0xc42002b710
testing.tRunner(0xc42007c340, 0x5483b0)
	/usr/lib/go/src/testing/testing.go:657 +0x96 fp=0xc42002b7d0 sp=0xc42002b7a8
runtime.goexit()
	/usr/lib/go/src/runtime/asm_amd64.s:2197 +0x1 fp=0xc42002b7d8 sp=0xc42002b7d0
created by testing.(*T).Run
	/usr/lib/go/src/testing/testing.go:697 +0x2ca

goroutine 1 [chan receive]:
testing.(*T).Run(0xc42007c000, 0x540de0, 0xe, 0x5483b0, 0x7de4c0)
	/usr/lib/go/src/testing/testing.go:698 +0x2f4
testing.runTests.func1(0xc42007c000)
	/usr/lib/go/src/testing/testing.go:882 +0x67
testing.tRunner(0xc42007c000, 0xc42003dde0)
	/usr/lib/go/src/testing/testing.go:657 +0x96
testing.runTests(0xc420088080, 0x7cbc60, 0x4, 0x4, 0xc42003de68)
	/usr/lib/go/src/testing/testing.go:888 +0x2c1
testing.(*M).Run(0xc42003df20, 0xc42003df20)
	/usr/lib/go/src/testing/testing.go:822 +0xfc
main.main()
	_/home/scott/swdunlop/go-liblzma/_test/_testmain.go:58 +0xf7

goroutine 17 [syscall, locked to thread]:
runtime.goexit()
	/usr/lib/go/src/runtime/asm_amd64.s:2197 +0x1
exit status 2
FAIL	_/home/scott/swdunlop/go-liblzma	0.281s
```