### PR TITLE
Fix decompressor losing data when reader returns n != 0 && err == io.EOF

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -55,10 +55,10 @@ func NewReader(r io.Reader) (*Decompressor, error) {
 
 func (r *Decompressor) Read(out []byte) (out_count int, er error) {
 	if r.offset >= r.length {
-		var n int
-		n, er = r.rd.Read(r.buffer)
-		if n == 0 {
-			return 0, er
+		n, err := r.rd.Read(r.buffer)
+
+		if err != nil && err != io.EOF {
+			return 0, err
 		}
 		r.offset, r.length = 0, n
 		r.handle.avail_in = C.size_t(n)
@@ -77,7 +77,7 @@ func (r *Decompressor) Read(out []byte) (out_count int, er error) {
 	r.offset = r.length - int(r.handle.avail_in)
 	switch Errno(ret) {
 	case Ok:
-		break
+		er = nil
 	case StreamEnd:
 		er = io.EOF
 	default:


### PR DESCRIPTION
This bug was caused by `Decompressor.Read` propagating `io.EOF` to its caller from underlying `io.Reader` regardless of LZMA stream status.

`io.Reader` may either return `err == io.EOF` (with `n != 0`) on the last read right away, or return `io.EOF` only on subsequent calls (with `n == 0`, obviously). 
Both behaviours are documented as acceptable in `io.Reader` interface description (https://golang.org/pkg/io/#Reader)

Although this seems to never happen with plain files, HTTP bodies from
`net/http` frequently exhibit this behaviour.